### PR TITLE
Allow arbitrary (defined) params through

### DIFF
--- a/src/AbstractGateway.php
+++ b/src/AbstractGateway.php
@@ -4,6 +4,7 @@ namespace Omnipay\Adyen;
 
 use Omnipay\Common\AbstractGateway as CommonAbstractGateway;
 use Omnipay\Adyen\Traits\GatewayParameters;
+use Omnipay\Adyen\Traits\PreservedParameters;
 use Omnipay\Adyen\Message\FetchPaymentMethodsRequest;
 use Omnipay\Adyen\Message\AuthorizeRequest;
 use Omnipay\Adyen\Message\CompleteAuthorizeRequest;
@@ -12,6 +13,7 @@ use Omnipay\Adyen\Message\CseClientRequest;
 abstract class AbstractGateway extends CommonAbstractGateway
 {
     use GatewayParameters;
+    use PreservedParameters;
 
     /**
      *

--- a/src/AbstractGateway.php
+++ b/src/AbstractGateway.php
@@ -5,6 +5,7 @@ namespace Omnipay\Adyen;
 use Omnipay\Common\AbstractGateway as CommonAbstractGateway;
 use Omnipay\Adyen\Traits\GatewayParameters;
 use Omnipay\Adyen\Traits\PreservedParameters;
+use Omnipay\Adyen\Traits\DebugLogging;
 use Omnipay\Adyen\Message\FetchPaymentMethodsRequest;
 use Omnipay\Adyen\Message\AuthorizeRequest;
 use Omnipay\Adyen\Message\CompleteAuthorizeRequest;
@@ -14,6 +15,7 @@ abstract class AbstractGateway extends CommonAbstractGateway
 {
     use GatewayParameters;
     use PreservedParameters;
+    use DebugLogging;
 
     /**
      *

--- a/src/Message/AbstractApiRequest.php
+++ b/src/Message/AbstractApiRequest.php
@@ -20,21 +20,30 @@ abstract class AbstractApiRequest extends AbstractRequest
     public function sendData($data)
     {
         $auth = $this->getUsername() . ':' . $this->getPassword();
+        $endpoint = $this->getEndpoint();
+        $headers = [
+            'Content-Type' => 'application/json',
+            // Basic auth header.
+            'Authorization' => 'Basic ' . base64_encode($auth)
+        ];
+        $body = json_encode($data);
 
-        $response = $this->httpClient->request(
-            'POST',
-            $this->getEndpoint(),
-            [
-                'Content-Type' => 'application/json',
-                // Basic auth header.
-                'Authorization' => 'Basic ' . base64_encode($auth)
-            ],
-            json_encode($data)
-        );
+        // Log the outgoing request
+        $this->logRequest('POST', $endpoint, $headers, $body);
 
-        $payload = $this->getJsonData($response);
+        try {
+            $response = $this->httpClient->request('POST', $endpoint, $headers, $body);
+            $payload = $this->getJsonData($response);
 
-        return $this->createResponse($payload);
+            // Log the response
+            $this->logResponse($endpoint, $response, $payload);
+
+            return $this->createResponse($payload);
+        } catch (\Throwable $e) {
+            // Log any errors
+            $this->logError($endpoint, $e);
+            throw $e;
+        }
     }
 
     /**

--- a/src/Message/AbstractCheckoutRequest.php
+++ b/src/Message/AbstractCheckoutRequest.php
@@ -86,6 +86,9 @@ abstract class AbstractCheckoutRequest extends AbstractApiRequest
             $data['riskData']['clientData'] = $this->getRiskData()['clientData'];
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/AbstractCheckoutRequest.php
+++ b/src/Message/AbstractCheckoutRequest.php
@@ -15,20 +15,29 @@ abstract class AbstractCheckoutRequest extends AbstractApiRequest
     public function sendData($data)
     {
         [$endpoint, $data] = $this->buildEndpointCleanData($data);
-        $response = $this->httpClient->request(
-            'POST',
-            $endpoint,
-            [
-                'Content-Type' => 'application/json',
-                // API Key header.
-                'x-api-key' => $this->getApiKey(),
-            ],
-            json_encode($data)
-        );
+        $headers = [
+            'Content-Type' => 'application/json',
+            // API Key header.
+            'x-api-key' => $this->getApiKey(),
+        ];
+        $body = json_encode($data);
 
-        $payload = $this->getJsonData($response);
+        // Log the outgoing request
+        $this->logRequest('POST', $endpoint, $headers, $body);
 
-        return $this->createResponse($payload);
+        try {
+            $response = $this->httpClient->request('POST', $endpoint, $headers, $body);
+            $payload = $this->getJsonData($response);
+
+            // Log the response
+            $this->logResponse($endpoint, $response, $payload);
+
+            return $this->createResponse($payload);
+        } catch (\Throwable $e) {
+            // Log any errors
+            $this->logError($endpoint, $e);
+            throw $e;
+        }
     }
 
     private function buildEndpointCleanData(array $parameters)

--- a/src/Message/AbstractHppRequest.php
+++ b/src/Message/AbstractHppRequest.php
@@ -22,18 +22,28 @@ abstract class AbstractHppRequest extends AbstractRequest
      */
     public function sendData($data)
     {
-        $response = $this->httpClient->request(
-            'POST',
-            $this->getEndpoint(),
-            [
-                'Content-Type' => 'application/x-www-form-urlencoded',
-            ],
-            http_build_query($data)
-        );
+        $endpoint = $this->getEndpoint();
+        $headers = [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+        $body = http_build_query($data);
 
-        $payload = $this->getJsonData($response);
+        // Log the outgoing request
+        $this->logRequest('POST', $endpoint, $headers, $data);
 
-        return $this->createResponse($payload);
+        try {
+            $response = $this->httpClient->request('POST', $endpoint, $headers, $body);
+            $payload = $this->getJsonData($response);
+
+            // Log the response
+            $this->logResponse($endpoint, $response, $payload);
+
+            return $this->createResponse($payload);
+        } catch (\Throwable $e) {
+            // Log any errors
+            $this->logError($endpoint, $e);
+            throw $e;
+        }
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -54,9 +54,9 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
     const DEFAULT_PREFIX_LIVE = '';
 
     const VERSION_DIRECTORY         = 'v2';
-    const VERSION_CHECKOUT          = 'v69';
+    const VERSION_CHECKOUT          = 'v71';
     const VERSION_CHECKOUT_UTILITY  = 'v1';
-    const VERSION_PAYMENT_PAYMENT   = 'v69';
+    const VERSION_PAYMENT_PAYMENT   = 'v71';
     const VERSION_PAYMENT_RECURRING = 'v25';
     const VERSION_PAYMENT_PAYOUT    = 'v30';
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -5,12 +5,14 @@ namespace Omnipay\Adyen\Message;
 use Omnipay\Common\Message\AbstractRequest as OmnipayAbstractRequest;
 use Omnipay\Adyen\Traits\GatewayParameters;
 use Omnipay\Adyen\Traits\PreservedParameters;
+use Omnipay\Adyen\Traits\DebugLogging;
 use Omnipay\Common\Exception\InvalidRequestException;
 
 abstract class AbstractRequest extends OmnipayAbstractRequest
 {
     use GatewayParameters;
     use PreservedParameters;
+    use DebugLogging;
 
     /**
      * Constants for URL construction.

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -4,11 +4,13 @@ namespace Omnipay\Adyen\Message;
 
 use Omnipay\Common\Message\AbstractRequest as OmnipayAbstractRequest;
 use Omnipay\Adyen\Traits\GatewayParameters;
+use Omnipay\Adyen\Traits\PreservedParameters;
 use Omnipay\Common\Exception\InvalidRequestException;
 
 abstract class AbstractRequest extends OmnipayAbstractRequest
 {
     use GatewayParameters;
+    use PreservedParameters;
 
     /**
      * Constants for URL construction.

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -15,6 +15,35 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
     use DebugLogging;
 
     /**
+     * Initialize the request with parameters.
+     *
+     * This override ensures that preserved parameters (which don't have explicit
+     * setter methods) are not discarded by Omnipay's Helper::initialize().
+     *
+     * @param array $parameters
+     * @return $this
+     */
+    public function initialize(array $parameters = [])
+    {
+        // Store original parameters before parent filters them
+        $originalParameters = $parameters;
+
+        // Let parent initialize (this sets preserved_parameter_keys among other things)
+        parent::initialize($parameters);
+
+        // Now manually set any parameters that are in the preserved list.
+        // These may have been filtered out by parent::initialize()
+        // because they don't have explicit setter methods.
+        foreach ($this->getPreservedParameterKeys() as $key) {
+            if (array_key_exists($key, $originalParameters)) {
+                $this->setParameter($key, $originalParameters[$key]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Constants for URL construction.
      */
 

--- a/src/Message/Api/AuthorizeRequest.php
+++ b/src/Message/Api/AuthorizeRequest.php
@@ -75,6 +75,9 @@ class AuthorizeRequest extends AbstractApiRequest
 
         $data = $this->addPaymentMethodData($data);
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/Api/CancelRequest.php
+++ b/src/Message/Api/CancelRequest.php
@@ -38,6 +38,9 @@ class CancelRequest extends AbstractApiRequest
             $data['reference'] = $transactionId;
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/Checkout/AuthorizeRequest.php
+++ b/src/Message/Checkout/AuthorizeRequest.php
@@ -81,6 +81,10 @@ class AuthorizeRequest extends AbstractCheckoutRequest
             $data['captureDelayHours'] = (int) $this->getCaptureDelayHours();
         }
 
+        if ($this->getTestMode() && !empty($this->getRequestedTestAcquirerResponseCode())) {
+            $data['additionalData']['RequestedTestAcquirerResponseCode'] = $this->getRequestedTestAcquirerResponseCode();
+        }
+
         $data = $this->addPaymentMethodData($data);
 
         if (isset($data['paymentMethod']['storedPaymentMethodId'])) {
@@ -113,11 +117,8 @@ class AuthorizeRequest extends AbstractCheckoutRequest
      * Get the payment data for the additionalData array.
      * In this case it is the CC details posted to the merchant site.
      * Be aware of PCI regulations when doing this.
-     *
-     * @return array
-     * @throws InvalidRequestException
      */
-    public function getPaymentMethodData()
+    public function getPaymentMethodData(): array
     {
         if (count($this->getPaymentMethod()) > 0) {
             return ['paymentMethod' => $this->getPaymentMethod()];
@@ -129,10 +130,8 @@ class AuthorizeRequest extends AbstractCheckoutRequest
     /**
      * If a credit card is supplied, then return the credit card
      * data, otherwise an empty array.
-     *
-     * @return array
      */
-    public function getCardData()
+    public function getCardData(): array
     {
         $data = [];
 
@@ -159,7 +158,7 @@ class AuthorizeRequest extends AbstractCheckoutRequest
         return $data;
     }
 
-    public function setCaptureDelayHours($captureDelayHours)
+    public function setCaptureDelayHours($captureDelayHours): void
     {
         $this->setParameter('captureDelayHours', $captureDelayHours);
     }
@@ -167,6 +166,13 @@ class AuthorizeRequest extends AbstractCheckoutRequest
     public function getCaptureDelayHours()
     {
         return $this->getParameter('captureDelayHours');
+    }
+
+    // This method is in use Adyen\Model\Checkout\AdditionalDataCommon
+    // We can look at importing model and using in this class?
+    public function getRequestedTestAcquirerResponseCode()
+    {
+        return $this->getParameter('requestedTestAcquirerResponseCode');
     }
 
 }

--- a/src/Message/Checkout/CompleteAuthorizeRequest.php
+++ b/src/Message/Checkout/CompleteAuthorizeRequest.php
@@ -36,6 +36,9 @@ class CompleteAuthorizeRequest extends AbstractCheckoutRequest
 
         //$data = $this->addDetailsData($data);
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/Checkout/CreateModificationRequest.php
+++ b/src/Message/Checkout/CreateModificationRequest.php
@@ -49,6 +49,9 @@ class CreateModificationRequest extends AbstractCheckoutRequest
             'modificationAction' => $this->getModificationAction(),
         ];
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
     public function setModificationAction($modificationAction)

--- a/src/Message/Checkout/CreateSessionRequest.php
+++ b/src/Message/Checkout/CreateSessionRequest.php
@@ -32,7 +32,7 @@ class CreateSessionRequest extends AbstractCheckoutRequest
 
         $data = [
             'amount' => [
-                'value' => 0,
+                'value' => $this->getAmountInteger() ?? 0,
                 'currency' => $this->getCurrency(),
             ],
             'merchantAccount' => $this->getMerchantAccount(),

--- a/src/Message/Checkout/CreateSessionRequest.php
+++ b/src/Message/Checkout/CreateSessionRequest.php
@@ -57,6 +57,9 @@ class CreateSessionRequest extends AbstractCheckoutRequest
             $data['shopperReference'] = $this->getShopperReference();
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/Checkout/CreateSessionRequest.php
+++ b/src/Message/Checkout/CreateSessionRequest.php
@@ -41,9 +41,7 @@ class CreateSessionRequest extends AbstractCheckoutRequest
             'countryCode' => $this->getCountryCode(),
         ];
 
-        if (!empty($this->getStorePaymentMethod())) {
-            $data['storePaymentMethod'] = $this->getStorePaymentMethod();
-        }
+        $data = $this->applyStorageParameters($data);
 
         if (!empty($this->getShopperInteraction())) {
             $data['shopperInteraction'] = $this->getShopperInteraction();
@@ -70,5 +68,30 @@ class CreateSessionRequest extends AbstractCheckoutRequest
     public function getStorePaymentMethod()
     {
         return $this->getParameter('storePaymentMethod');
+    }
+
+    public function setStorePaymentMethodMode($storePaymentMethodMode)
+    {
+        $this->setParameter('storePaymentMethodMode', $storePaymentMethodMode);
+    }
+    public function getStorePaymentMethodMode()
+    {
+        return $this->getParameter('storePaymentMethodMode');
+    }
+
+    private function applyStorageParameters(array $data): array
+    {
+        // If the new mode is set, use it and ignore the old boolean
+        if ($mode = $this->getStorePaymentMethodMode()) {
+            $data['storePaymentMethodMode'] = $mode;
+            return $data;
+        }
+
+        // Fallback to the legacy boolean for older versions
+        if ($store = $this->getStorePaymentMethod()) {
+            $data['storePaymentMethod'] = $store;
+        }
+
+        return $data;
     }
 }

--- a/src/Message/Checkout/PaymentMethodRequest.php
+++ b/src/Message/Checkout/PaymentMethodRequest.php
@@ -48,6 +48,9 @@ class PaymentMethodRequest extends AbstractCheckoutRequest
             $data['shopperReference'] = $this->getShopperReference();
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 }

--- a/src/Message/Hpp/AuthorizeRequest.php
+++ b/src/Message/Hpp/AuthorizeRequest.php
@@ -100,6 +100,10 @@ class AuthorizeRequest extends AbstractHppRequest
             }
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        // (must be done before signature generation)
+        $data = $this->mergePreservedParameters($data);
+
         // Finally add the HMAC signature for the data.
 
         $signingString = $this->getSigningString($data);

--- a/src/Message/Hpp/FetchPaymentMethodsRequest.php
+++ b/src/Message/Hpp/FetchPaymentMethodsRequest.php
@@ -46,6 +46,10 @@ class FetchPaymentMethodsRequest extends AbstractHppRequest
             $data['blockedMethods'] = $this->getBlockedMethods();
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        // (must be done before signature generation)
+        $data = $this->mergePreservedParameters($data);
+
         // Finally add the HMAC signature for the data.
 
         $signingString = $this->getSigningString($data);

--- a/src/Traits/DebugLogging.php
+++ b/src/Traits/DebugLogging.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace Omnipay\Adyen\Traits;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Trait for debug logging of Adyen API requests and responses.
+ *
+ * This allows userland code to enable logging to validate exactly what
+ * was sent to Adyen and what they responded with.
+ *
+ * Usage with a closure:
+ *   $gateway->setDebugMode(true);
+ *   $gateway->setDebugLogger(function (string $message, array $context) {
+ *       Log::debug($message, $context);
+ *   });
+ *
+ * Usage with a PSR-3 logger:
+ *   $gateway->setDebugMode(true);
+ *   $gateway->setDebugLogger(function (string $message, array $context) use ($logger) {
+ *       $logger->debug($message, $context);
+ *   });
+ *
+ * The logger callable receives:
+ *   - $message: A descriptive message like "Adyen API Request" or "Adyen API Response"
+ *   - $context: An array with details like 'endpoint', 'method', 'headers', 'body', 'status_code', etc.
+ */
+trait DebugLogging
+{
+    /**
+     * Get whether debug mode is enabled.
+     *
+     * @return bool
+     */
+    public function getDebugMode(): bool
+    {
+        return (bool) $this->getParameter('debugMode');
+    }
+
+    /**
+     * Enable or disable debug mode.
+     *
+     * @param bool $enabled
+     * @return $this
+     */
+    public function setDebugMode(bool $enabled)
+    {
+        return $this->setParameter('debugMode', $enabled);
+    }
+
+    /**
+     * Get the debug logger callable.
+     *
+     * @return callable|null
+     */
+    public function getDebugLogger(): ?callable
+    {
+        return $this->getParameter('debugLogger');
+    }
+
+    /**
+     * Set the debug logger callable.
+     *
+     * The callable should accept two parameters:
+     *   - string $message: The log message
+     *   - array $context: Context data (endpoint, headers, body, etc.)
+     *
+     * @param callable|null $logger
+     * @return $this
+     */
+    public function setDebugLogger(?callable $logger)
+    {
+        return $this->setParameter('debugLogger', $logger);
+    }
+
+    /**
+     * Log a debug message if debug mode is enabled and a logger is configured.
+     *
+     * @param string $message
+     * @param array $context
+     * @return void
+     */
+    protected function debugLog(string $message, array $context = []): void
+    {
+        if (!$this->getDebugMode()) {
+            return;
+        }
+
+        $logger = $this->getDebugLogger();
+
+        if ($logger === null) {
+            return;
+        }
+
+        call_user_func($logger, $message, $context);
+    }
+
+    /**
+     * Log an outgoing API request.
+     *
+     * @param string $method HTTP method (POST, GET, etc.)
+     * @param string $endpoint The API endpoint URL
+     * @param array $headers Request headers (sensitive values will be masked)
+     * @param mixed $body The request body (will be decoded if JSON string)
+     * @return void
+     */
+    protected function logRequest(string $method, string $endpoint, array $headers, $body): void
+    {
+        $context = [
+            'direction' => 'request',
+            'method' => $method,
+            'endpoint' => $endpoint,
+            'headers' => $this->maskSensitiveHeaders($headers),
+            'body' => $this->formatBody($body),
+            'timestamp' => date('c'),
+        ];
+
+        $this->debugLog('Adyen API Request', $context);
+    }
+
+    /**
+     * Log an incoming API response.
+     *
+     * @param string $endpoint The API endpoint URL
+     * @param ResponseInterface $response The PSR-7 response object
+     * @param mixed $payload The decoded response payload
+     * @return void
+     */
+    protected function logResponse(string $endpoint, ResponseInterface $response, $payload): void
+    {
+        $context = [
+            'direction' => 'response',
+            'endpoint' => $endpoint,
+            'status_code' => $response->getStatusCode(),
+            'reason_phrase' => $response->getReasonPhrase(),
+            'headers' => $response->getHeaders(),
+            'body' => $this->maskSensitiveData($payload),
+            'timestamp' => date('c'),
+        ];
+
+        $this->debugLog('Adyen API Response', $context);
+    }
+
+    /**
+     * Log an error during API communication.
+     *
+     * @param string $endpoint The API endpoint URL
+     * @param \Throwable $exception The exception that occurred
+     * @return void
+     */
+    protected function logError(string $endpoint, \Throwable $exception): void
+    {
+        $context = [
+            'direction' => 'error',
+            'endpoint' => $endpoint,
+            'error_class' => get_class($exception),
+            'error_message' => $exception->getMessage(),
+            'error_code' => $exception->getCode(),
+            'timestamp' => date('c'),
+        ];
+
+        $this->debugLog('Adyen API Error', $context);
+    }
+
+    /**
+     * Mask sensitive values in headers.
+     *
+     * @param array $headers
+     * @return array
+     */
+    protected function maskSensitiveHeaders(array $headers): array
+    {
+        $sensitiveHeaders = ['Authorization', 'authorization', 'x-api-key', 'X-API-Key'];
+        $masked = [];
+
+        foreach ($headers as $name => $value) {
+            if (in_array($name, $sensitiveHeaders, true)) {
+                // Show first and last few characters for debugging
+                $valueStr = is_array($value) ? implode(', ', $value) : $value;
+                if (strlen($valueStr) > 12) {
+                    $masked[$name] = substr($valueStr, 0, 6) . '***' . substr($valueStr, -4);
+                } else {
+                    $masked[$name] = str_repeat('*', strlen($valueStr));
+                }
+            } else {
+                $masked[$name] = $value;
+            }
+        }
+
+        return $masked;
+    }
+
+    /**
+     * Format the request body for logging.
+     *
+     * @param mixed $body
+     * @return mixed
+     */
+    protected function formatBody($body)
+    {
+        // If it's a JSON string, decode it for better readability
+        if (is_string($body)) {
+            $decoded = json_decode($body, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return $this->maskSensitiveData($decoded);
+            }
+        }
+
+        if (is_array($body)) {
+            return $this->maskSensitiveData($body);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Mask sensitive data in the payload.
+     *
+     * @param mixed $data
+     * @return mixed
+     */
+    protected function maskSensitiveData($data)
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        $sensitiveKeys = [
+            'number', 'cardNumber', 'encryptedCardNumber',
+            'cvc', 'cvv', 'encryptedSecurityCode',
+            'expiryMonth', 'expiryYear', 'encryptedExpiryMonth', 'encryptedExpiryYear',
+            'password', 'secret',
+        ];
+
+        $masked = [];
+
+        foreach ($data as $key => $value) {
+            if (in_array($key, $sensitiveKeys, true)) {
+                if (is_string($value) && strlen($value) > 4) {
+                    $masked[$key] = str_repeat('*', strlen($value) - 4) . substr($value, -4);
+                } else {
+                    $masked[$key] = str_repeat('*', strlen($value));
+                }
+            } elseif (is_array($value)) {
+                $masked[$key] = $this->maskSensitiveData($value);
+            } else {
+                $masked[$key] = $value;
+            }
+        }
+
+        return $masked;
+    }
+}

--- a/src/Traits/DebugLogging.php
+++ b/src/Traits/DebugLogging.php
@@ -35,7 +35,7 @@ trait DebugLogging
      */
     public function getDebugMode(): bool
     {
-        return (bool) $this->getParameter('debugMode');
+        return (bool) $this->getParameter('debug_mode');
     }
 
     /**
@@ -46,7 +46,7 @@ trait DebugLogging
      */
     public function setDebugMode(bool $enabled)
     {
-        return $this->setParameter('debugMode', $enabled);
+        return $this->setParameter('debug_mode', $enabled);
     }
 
     /**
@@ -56,7 +56,7 @@ trait DebugLogging
      */
     public function getDebugLogger(): ?callable
     {
-        return $this->getParameter('debugLogger');
+        return $this->getParameter('debug_logger');
     }
 
     /**
@@ -71,7 +71,7 @@ trait DebugLogging
      */
     public function setDebugLogger(?callable $logger)
     {
-        return $this->setParameter('debugLogger', $logger);
+        return $this->setParameter('debug_logger', $logger);
     }
 
     /**

--- a/src/Traits/PreservedParameters.php
+++ b/src/Traits/PreservedParameters.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Omnipay\Adyen\Traits;
+
+/**
+ * Trait for handling additional parameters that should be preserved and passed through to the API.
+ *
+ * This allows userland code to pass extra parameters through to Adyen without requiring
+ * modifications to the package for each new parameter.
+ *
+ * Usage:
+ *   // First, declare which parameters should be preserved
+ *   $gateway->setPreservedParameterKeys(['lineItems', 'metadata', 'applicationInfo']);
+ *
+ *   // Then, when making requests, those parameters will be included if set
+ *   $gateway->session([
+ *       'amount' => '10.00',
+ *       'lineItems' => [...],  // This will be preserved
+ *       'metadata' => [...],   // This will be preserved
+ *   ]);
+ */
+trait PreservedParameters
+{
+    /**
+     * Get the list of parameter keys that should be preserved.
+     *
+     * @return array
+     */
+    public function getPreservedParameterKeys(): array
+    {
+        return $this->getParameter('preservedParameterKeys') ?? [];
+    }
+
+    /**
+     * Set the list of parameter keys that should be preserved.
+     *
+     * @param array $keys Array of parameter names to preserve
+     * @return $this
+     */
+    public function setPreservedParameterKeys(array $keys)
+    {
+        return $this->setParameter('preservedParameterKeys', $keys);
+    }
+
+    /**
+     * Add a single parameter key to the preserved list.
+     *
+     * @param string $key The parameter name to preserve
+     * @return $this
+     */
+    public function addPreservedParameterKey(string $key)
+    {
+        $keys = $this->getPreservedParameterKeys();
+
+        if (!in_array($key, $keys, true)) {
+            $keys[] = $key;
+        }
+
+        return $this->setPreservedParameterKeys($keys);
+    }
+
+    /**
+     * Remove a parameter key from the preserved list.
+     *
+     * @param string $key The parameter name to remove
+     * @return $this
+     */
+    public function removePreservedParameterKey(string $key)
+    {
+        $keys = $this->getPreservedParameterKeys();
+        $keys = array_filter($keys, fn($k) => $k !== $key);
+
+        return $this->setPreservedParameterKeys(array_values($keys));
+    }
+
+    /**
+     * Get the data for all preserved parameters that have values.
+     *
+     * This method iterates through the preserved parameter keys and returns
+     * an associative array of key => value for all parameters that have been set.
+     *
+     * @return array
+     */
+    public function getPreservedParametersData(): array
+    {
+        $data = [];
+
+        foreach ($this->getPreservedParameterKeys() as $key) {
+            $value = $this->getParameter($key);
+
+            if ($value !== null) {
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Merge preserved parameters into an existing data array.
+     *
+     * This is a convenience method for use in getData() implementations.
+     * Preserved parameters will NOT override existing keys in the data array.
+     *
+     * @param array $data The existing data array
+     * @return array The merged data array
+     */
+    public function mergePreservedParameters(array $data): array
+    {
+        $preserved = $this->getPreservedParametersData();
+
+        // Only add preserved parameters that don't already exist in data
+        foreach ($preserved as $key => $value) {
+            if (!array_key_exists($key, $data)) {
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/src/Traits/PreservedParameters.php
+++ b/src/Traits/PreservedParameters.php
@@ -28,7 +28,7 @@ trait PreservedParameters
      */
     public function getPreservedParameterKeys(): array
     {
-        return $this->getParameter('preservedParameterKeys') ?? [];
+        return $this->getParameter('preserved_parameter_keys') ?? [];
     }
 
     /**
@@ -39,7 +39,7 @@ trait PreservedParameters
      */
     public function setPreservedParameterKeys(array $keys)
     {
-        return $this->setParameter('preservedParameterKeys', $keys);
+        return $this->setParameter('preserved_parameter_keys', $keys);
     }
 
     /**

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -31,7 +31,7 @@ class AbstractRequestTest extends TestCase
         $url = $this->request->getCheckoutUrl('payments');
         
         $this->assertEquals(
-            'https://checkout-test.adyen.com/v69/payments',
+            'https://checkout-test.adyen.com/' . AbstractRequest::VERSION_CHECKOUT . '/payments',
             $url
         );
     }
@@ -44,7 +44,7 @@ class AbstractRequestTest extends TestCase
         $url = $this->request->getCheckoutUrl('payments');
         
         $this->assertEquals(
-            'https://checkout-live.adyenpayments.com/checkout/v69/payments',
+            'https://checkout-live.adyenpayments.com/checkout/' . AbstractRequest::VERSION_CHECKOUT . '/payments',
             $url
         );
 
@@ -55,7 +55,7 @@ class AbstractRequestTest extends TestCase
         $url = $this->request->getCheckoutUrl('payments');
         
         $this->assertEquals(
-            'https://xxx-xxx-checkout-custom.adyenpayments.com/checkout/v69/payments',
+            'https://xxx-xxx-checkout-custom.adyenpayments.com/checkout/' . AbstractRequest::VERSION_CHECKOUT . '/payments',
             $url
         );
     }

--- a/tests/Traits/DebugLoggingTest.php
+++ b/tests/Traits/DebugLoggingTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Omnipay\Adyen\Tests\Traits;
+
+use Omnipay\Adyen\Message\AbstractRequest;
+use PHPUnit\Framework\TestCase;
+use Omnipay\Common\Http\ClientInterface;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+
+/**
+ * Concrete implementation of AbstractRequest for testing debug logging
+ */
+class TestableLoggingRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        return [];
+    }
+
+    public function sendData($data)
+    {
+        return null;
+    }
+
+    // Expose protected methods for testing
+    public function testLogRequest(string $method, string $endpoint, array $headers, $body): void
+    {
+        $this->logRequest($method, $endpoint, $headers, $body);
+    }
+
+    public function testDebugLog(string $message, array $context = []): void
+    {
+        $this->debugLog($message, $context);
+    }
+
+    public function testMaskSensitiveHeaders(array $headers): array
+    {
+        return $this->maskSensitiveHeaders($headers);
+    }
+
+    public function testMaskSensitiveData($data)
+    {
+        return $this->maskSensitiveData($data);
+    }
+
+    public function testFormatBody($body)
+    {
+        return $this->formatBody($body);
+    }
+}
+
+class DebugLoggingTest extends TestCase
+{
+    protected TestableLoggingRequest $request;
+
+    protected function setUp(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpRequest = $this->createMock(HttpRequest::class);
+        $this->request = new TestableLoggingRequest($httpClient, $httpRequest);
+    }
+
+    public function test_setDebugMode_stores_value()
+    {
+        $result = $this->request->setDebugMode(true);
+
+        $this->assertSame($this->request, $result); // Should return $this for chaining
+        $this->assertTrue($this->request->getDebugMode());
+
+        $this->request->setDebugMode(false);
+        $this->assertFalse($this->request->getDebugMode());
+    }
+
+    public function test_getDebugMode_returns_false_by_default()
+    {
+        $this->assertFalse($this->request->getDebugMode());
+    }
+
+    public function test_setDebugLogger_stores_callable()
+    {
+        $logger = function (string $message, array $context) {
+            // Test logger
+        };
+
+        $result = $this->request->setDebugLogger($logger);
+
+        $this->assertSame($this->request, $result); // Should return $this for chaining
+        $this->assertSame($logger, $this->request->getDebugLogger());
+    }
+
+    public function test_getDebugLogger_returns_null_by_default()
+    {
+        $this->assertNull($this->request->getDebugLogger());
+    }
+
+    public function test_debugLog_calls_logger_when_enabled()
+    {
+        $loggedMessages = [];
+
+        $this->request->setDebugMode(true);
+        $this->request->setDebugLogger(function (string $message, array $context) use (&$loggedMessages) {
+            $loggedMessages[] = ['message' => $message, 'context' => $context];
+        });
+
+        $this->request->testDebugLog('Test message', ['key' => 'value']);
+
+        $this->assertCount(1, $loggedMessages);
+        $this->assertEquals('Test message', $loggedMessages[0]['message']);
+        $this->assertEquals(['key' => 'value'], $loggedMessages[0]['context']);
+    }
+
+    public function test_debugLog_does_not_call_logger_when_disabled()
+    {
+        $loggedMessages = [];
+
+        $this->request->setDebugMode(false);
+        $this->request->setDebugLogger(function (string $message, array $context) use (&$loggedMessages) {
+            $loggedMessages[] = ['message' => $message, 'context' => $context];
+        });
+
+        $this->request->testDebugLog('Test message', ['key' => 'value']);
+
+        $this->assertCount(0, $loggedMessages);
+    }
+
+    public function test_debugLog_does_not_fail_without_logger()
+    {
+        $this->request->setDebugMode(true);
+        // No logger set
+
+        // Should not throw an exception
+        $this->request->testDebugLog('Test message', ['key' => 'value']);
+
+        $this->assertTrue(true); // If we get here, the test passed
+    }
+
+    public function test_logRequest_logs_correct_context()
+    {
+        $loggedMessages = [];
+
+        $this->request->setDebugMode(true);
+        $this->request->setDebugLogger(function (string $message, array $context) use (&$loggedMessages) {
+            $loggedMessages[] = ['message' => $message, 'context' => $context];
+        });
+
+        $this->request->testLogRequest(
+            'POST',
+            'https://checkout-test.adyen.com/v69/payments',
+            ['Content-Type' => 'application/json', 'x-api-key' => 'test_api_key_12345'],
+            ['amount' => ['value' => 1000, 'currency' => 'USD']]
+        );
+
+        $this->assertCount(1, $loggedMessages);
+        $this->assertEquals('Adyen API Request', $loggedMessages[0]['message']);
+        $this->assertEquals('request', $loggedMessages[0]['context']['direction']);
+        $this->assertEquals('POST', $loggedMessages[0]['context']['method']);
+        $this->assertEquals('https://checkout-test.adyen.com/v69/payments', $loggedMessages[0]['context']['endpoint']);
+        $this->assertArrayHasKey('timestamp', $loggedMessages[0]['context']);
+    }
+
+    public function test_maskSensitiveHeaders_masks_authorization()
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+            'x-api-key' => 'test_api_key_very_long_value',
+        ];
+
+        $masked = $this->request->testMaskSensitiveHeaders($headers);
+
+        $this->assertEquals('application/json', $masked['Content-Type']);
+        $this->assertNotEquals('Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $masked['Authorization']);
+        $this->assertStringContainsString('***', $masked['Authorization']);
+        $this->assertNotEquals('test_api_key_very_long_value', $masked['x-api-key']);
+        $this->assertStringContainsString('***', $masked['x-api-key']);
+    }
+
+    public function test_maskSensitiveHeaders_shows_partial_value()
+    {
+        $headers = [
+            'Authorization' => 'Basic abcdefghijklmnop',
+        ];
+
+        $masked = $this->request->testMaskSensitiveHeaders($headers);
+
+        // Should show first 6 and last 4 characters
+        $this->assertEquals('Basic ***mnop', $masked['Authorization']);
+    }
+
+    public function test_maskSensitiveData_masks_card_number()
+    {
+        $data = [
+            'paymentMethod' => [
+                'type' => 'scheme',
+                'number' => '4111111111111111',
+                'cvc' => '123',
+                'expiryMonth' => '03',
+                'expiryYear' => '2030',
+            ],
+            'amount' => [
+                'value' => 1000,
+                'currency' => 'USD',
+            ],
+        ];
+
+        $masked = $this->request->testMaskSensitiveData($data);
+
+        // Card number should be masked
+        $this->assertStringContainsString('1111', $masked['paymentMethod']['number']);
+        $this->assertStringContainsString('*', $masked['paymentMethod']['number']);
+        $this->assertNotEquals('4111111111111111', $masked['paymentMethod']['number']);
+
+        // CVC should be masked
+        $this->assertEquals('***', $masked['paymentMethod']['cvc']);
+
+        // Expiry should be masked
+        $this->assertStringContainsString('*', $masked['paymentMethod']['expiryMonth']);
+        $this->assertStringContainsString('*', $masked['paymentMethod']['expiryYear']);
+
+        // Amount should not be masked
+        $this->assertEquals(1000, $masked['amount']['value']);
+        $this->assertEquals('USD', $masked['amount']['currency']);
+    }
+
+    public function test_maskSensitiveData_handles_nested_arrays()
+    {
+        $data = [
+            'level1' => [
+                'level2' => [
+                    'number' => '4111111111111111',
+                    'safe' => 'visible',
+                ],
+            ],
+        ];
+
+        $masked = $this->request->testMaskSensitiveData($data);
+
+        $this->assertNotEquals('4111111111111111', $masked['level1']['level2']['number']);
+        $this->assertEquals('visible', $masked['level1']['level2']['safe']);
+    }
+
+    public function test_formatBody_decodes_json_string()
+    {
+        $jsonBody = '{"amount":{"value":1000,"currency":"USD"}}';
+
+        $formatted = $this->request->testFormatBody($jsonBody);
+
+        $this->assertIsArray($formatted);
+        $this->assertEquals(1000, $formatted['amount']['value']);
+        $this->assertEquals('USD', $formatted['amount']['currency']);
+    }
+
+    public function test_formatBody_returns_array_as_is()
+    {
+        $arrayBody = ['amount' => ['value' => 1000, 'currency' => 'USD']];
+
+        $formatted = $this->request->testFormatBody($arrayBody);
+
+        $this->assertEquals($arrayBody, $formatted);
+    }
+
+    public function test_formatBody_returns_non_json_string_as_is()
+    {
+        $nonJsonBody = 'key1=value1&key2=value2';
+
+        $formatted = $this->request->testFormatBody($nonJsonBody);
+
+        $this->assertEquals($nonJsonBody, $formatted);
+    }
+
+    public function test_formatBody_masks_sensitive_data_in_json()
+    {
+        $jsonBody = '{"paymentMethod":{"number":"4111111111111111"}}';
+
+        $formatted = $this->request->testFormatBody($jsonBody);
+
+        $this->assertNotEquals('4111111111111111', $formatted['paymentMethod']['number']);
+    }
+}
+

--- a/tests/Traits/PreservedParametersTest.php
+++ b/tests/Traits/PreservedParametersTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Omnipay\Adyen\Tests\Traits;
+
+use Omnipay\Adyen\Message\AbstractRequest;
+use PHPUnit\Framework\TestCase;
+use Omnipay\Common\Http\ClientInterface;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+
+/**
+ * Concrete implementation of AbstractRequest for testing
+ */
+class TestableRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $data = [
+            'merchantAccount' => $this->getMerchantAccount(),
+            'amount' => $this->getAmountInteger(),
+        ];
+
+        // Merge preserved parameters like the real request classes do
+        $data = $this->mergePreservedParameters($data);
+
+        return $data;
+    }
+
+    public function sendData($data)
+    {
+        return null;
+    }
+}
+
+class PreservedParametersTest extends TestCase
+{
+    protected TestableRequest $request;
+
+    protected function setUp(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpRequest = $this->createMock(HttpRequest::class);
+        $this->request = new TestableRequest($httpClient, $httpRequest);
+    }
+
+    public function test_setPreservedParameterKeys_stores_keys()
+    {
+        $keys = ['lineItems', 'metadata', 'applicationInfo'];
+
+        $result = $this->request->setPreservedParameterKeys($keys);
+
+        $this->assertSame($this->request, $result); // Should return $this for chaining
+        $this->assertEquals($keys, $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_getPreservedParameterKeys_returns_empty_array_by_default()
+    {
+        $this->assertEquals([], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_addPreservedParameterKey_adds_single_key()
+    {
+        $this->request->addPreservedParameterKey('lineItems');
+        $this->request->addPreservedParameterKey('metadata');
+
+        $this->assertEquals(['lineItems', 'metadata'], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_addPreservedParameterKey_does_not_duplicate_keys()
+    {
+        $this->request->addPreservedParameterKey('lineItems');
+        $this->request->addPreservedParameterKey('lineItems');
+        $this->request->addPreservedParameterKey('metadata');
+        $this->request->addPreservedParameterKey('lineItems');
+
+        $this->assertEquals(['lineItems', 'metadata'], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_removePreservedParameterKey_removes_key()
+    {
+        $this->request->setPreservedParameterKeys(['lineItems', 'metadata', 'applicationInfo']);
+
+        $result = $this->request->removePreservedParameterKey('metadata');
+
+        $this->assertSame($this->request, $result); // Should return $this for chaining
+        $this->assertEquals(['lineItems', 'applicationInfo'], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_removePreservedParameterKey_handles_nonexistent_key()
+    {
+        $this->request->setPreservedParameterKeys(['lineItems', 'metadata']);
+
+        $this->request->removePreservedParameterKey('nonexistent');
+
+        $this->assertEquals(['lineItems', 'metadata'], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_getPreservedParametersData_returns_set_parameters()
+    {
+        $lineItems = [
+            ['description' => 'Product 1', 'quantity' => 1],
+            ['description' => 'Product 2', 'quantity' => 2],
+        ];
+        $metadata = ['orderId' => '12345'];
+
+        $this->request->setPreservedParameterKeys(['lineItems', 'metadata', 'applicationInfo']);
+        $this->request->setParameter('lineItems', $lineItems);
+        $this->request->setParameter('metadata', $metadata);
+        // applicationInfo is not set, so it should be excluded
+
+        $data = $this->request->getPreservedParametersData();
+
+        $this->assertEquals([
+            'lineItems' => $lineItems,
+            'metadata' => $metadata,
+        ], $data);
+    }
+
+    public function test_getPreservedParametersData_excludes_null_values()
+    {
+        $this->request->setPreservedParameterKeys(['lineItems', 'metadata']);
+        $this->request->setParameter('lineItems', null);
+        $this->request->setParameter('metadata', ['key' => 'value']);
+
+        $data = $this->request->getPreservedParametersData();
+
+        $this->assertEquals([
+            'metadata' => ['key' => 'value'],
+        ], $data);
+    }
+
+    public function test_mergePreservedParameters_adds_to_data_array()
+    {
+        $lineItems = [['description' => 'Product 1']];
+
+        $this->request->setPreservedParameterKeys(['lineItems']);
+        $this->request->setParameter('lineItems', $lineItems);
+
+        $existingData = ['merchantAccount' => 'TestMerchant', 'amount' => 1000];
+
+        $result = $this->request->mergePreservedParameters($existingData);
+
+        $this->assertEquals([
+            'merchantAccount' => 'TestMerchant',
+            'amount' => 1000,
+            'lineItems' => $lineItems,
+        ], $result);
+    }
+
+    public function test_mergePreservedParameters_does_not_override_existing_keys()
+    {
+        $this->request->setPreservedParameterKeys(['amount', 'lineItems']);
+        $this->request->setParameter('amount', 9999); // Try to override
+        $this->request->setParameter('lineItems', [['item' => 1]]);
+
+        $existingData = ['merchantAccount' => 'TestMerchant', 'amount' => 1000];
+
+        $result = $this->request->mergePreservedParameters($existingData);
+
+        // amount should NOT be overridden
+        $this->assertEquals(1000, $result['amount']);
+        // lineItems should be added
+        $this->assertEquals([['item' => 1]], $result['lineItems']);
+    }
+
+    public function test_getData_includes_preserved_parameters()
+    {
+        $lineItems = [['description' => 'Test Product', 'quantity' => 1]];
+
+        $this->request->setMerchantAccount('TestMerchant');
+        $this->request->setAmount('10.00');
+        $this->request->setPreservedParameterKeys(['lineItems']);
+        $this->request->setParameter('lineItems', $lineItems);
+
+        $data = $this->request->getData();
+
+        $this->assertEquals('TestMerchant', $data['merchantAccount']);
+        $this->assertEquals(1000, $data['amount']);
+        $this->assertEquals($lineItems, $data['lineItems']);
+    }
+
+    public function test_preserved_parameters_support_nested_arrays()
+    {
+        $complexData = [
+            'level1' => [
+                'level2' => [
+                    'level3' => 'value',
+                    'items' => [1, 2, 3],
+                ],
+            ],
+        ];
+
+        $this->request->setPreservedParameterKeys(['complexData']);
+        $this->request->setParameter('complexData', $complexData);
+
+        $data = $this->request->getPreservedParametersData();
+
+        $this->assertEquals(['complexData' => $complexData], $data);
+    }
+
+    public function test_preserved_parameters_empty_when_no_keys_set()
+    {
+        $this->request->setParameter('lineItems', [['item' => 1]]);
+        $this->request->setParameter('metadata', ['key' => 'value']);
+
+        // No preserved parameter keys set
+        $data = $this->request->getPreservedParametersData();
+
+        $this->assertEquals([], $data);
+    }
+}
+

--- a/tests/Traits/PreservedParametersTest.php
+++ b/tests/Traits/PreservedParametersTest.php
@@ -207,5 +207,60 @@ class PreservedParametersTest extends TestCase
 
         $this->assertEquals([], $data);
     }
+
+    public function test_initialize_preserves_parameters_without_setters()
+    {
+        // This simulates what happens when Omnipay's createRequest() calls initialize()
+        // Parameters without explicit setters would normally be discarded by Helper::initialize()
+        // Our override of initialize() should capture them.
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpRequest = $this->createMock(HttpRequest::class);
+        $request = new TestableRequest($httpClient, $httpRequest);
+
+        // Initialize with preserved_parameter_keys and a custom parameter
+        $request->initialize([
+            'merchantAccount' => 'TestMerchant',
+            'preserved_parameter_keys' => ['enableRecurring', 'customField'],
+            'enableRecurring' => true,
+            'customField' => 'customValue',
+        ]);
+
+        // The preserved parameters should be available
+        $this->assertEquals(['enableRecurring', 'customField'], $request->getPreservedParameterKeys());
+        $this->assertTrue($request->getParameter('enableRecurring'));
+        $this->assertEquals('customValue', $request->getParameter('customField'));
+
+        // And they should be merged into getData()
+        $data = $request->getData();
+        $this->assertTrue($data['enableRecurring']);
+        $this->assertEquals('customValue', $data['customField']);
+    }
+
+    public function test_initialize_preserves_only_specified_keys()
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpRequest = $this->createMock(HttpRequest::class);
+        $request = new TestableRequest($httpClient, $httpRequest);
+
+        // Initialize with preserved_parameter_keys but also include a non-preserved parameter
+        $request->initialize([
+            'merchantAccount' => 'TestMerchant',
+            'preserved_parameter_keys' => ['enableRecurring'],
+            'enableRecurring' => true,
+            'notPreserved' => 'should be discarded',
+        ]);
+
+        // enableRecurring should be preserved
+        $this->assertTrue($request->getParameter('enableRecurring'));
+
+        // notPreserved should NOT be preserved (no setter, not in preserved list)
+        $this->assertNull($request->getParameter('notPreserved'));
+
+        // Only enableRecurring should appear in getData()
+        $data = $request->getData();
+        $this->assertTrue($data['enableRecurring']);
+        $this->assertArrayNotHasKey('notPreserved', $data);
+    }
 }
 


### PR DESCRIPTION
We keep running into issues where we need to pass additional parameters through to Adyen, and we have to update this package to accomplish it. While I appreciate its whitelist approach, this has proven restrictive.

This PR allows us to define parameters we want to allow through first (sticking with the "whitelist" approach), and then pass those arbitrary parameters through in the various requests.

Additionally, I added the ability to log the request and response to any arbitrary log channel (i.e. the Laravel log channel) for debug purposes.